### PR TITLE
Baudrate config fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This is just some basic usage. This driver is `alpha` quality; thus the API is s
     } catch (e) {
         // called if can't get a port
         console.warn("Error connecting to port: " + e.error)
+        console.warn(e)
     }
     
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,15 @@ This is just some basic usage. This driver is `alpha` quality; thus the API is s
 
     // get a device object
     var device = new WebUSBSerialDevice({
-        overridePortSettings: false,
+        overridePortSettings: true, // TODO: not supported yet, always overrides baudrate
         // these are the defaults, this config is only used if above is true
         baudrate: 9600,
-        bits: 8,
-        stop: 1,
-        parity: false
+        bits: 8, // TODO: override not supported yet
+        stop: 1, // TODO: override not supported yet
+        parity: false, // TODO: override not supported yet
+        deviceFilters : [
+            { 'vendorId': 0x0403, 'productId': 0x6001}, // 0403:6001 Future Technology Devices International, Ltd FT232 Serial (UART) IC
+        ]
     });
     
     // get available ports (ftdi devices)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This is just some basic usage. This driver is `alpha` quality; thus the API is s
         });
     } catch (e) {
         // called if can't get a port
-        console.warn("Error connecting to port: " + e.error
+        console.warn("Error connecting to port: " + e.error)
     }
     
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This is just some basic usage. This driver is `alpha` quality; thus the API is s
     var device = new WebUSBSerialDevice({
         overridePortSettings: false,
         // these are the defaults, this config is only used if above is true
-        baud: 9600,
+        baudrate: 9600,
         bits: 8,
         stop: 1,
         parity: false

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This is just some basic usage. This driver is `alpha` quality; thus the API is s
         stop: 1, // TODO: override not supported yet
         parity: false, // TODO: override not supported yet
         deviceFilters : [
+	    // example filtered device; see code for more examples
             { 'vendorId': 0x0403, 'productId': 0x6001}, // 0403:6001 Future Technology Devices International, Ltd FT232 Serial (UART) IC
         ]
     });

--- a/webusb-ftdi.js
+++ b/webusb-ftdi.js
@@ -601,8 +601,9 @@ class WebUSBSerialPort {
 	 *
 	 */
 
-	constructor(device) {
+	constructor(device, portConfiguration) {
 		this.device = device;
+		this.portConfiguration = portConfiguration;
 
 		this.interfaceNumber = 0;
 		this.endpointIn = 0;
@@ -682,7 +683,7 @@ class WebUSBSerialPort {
 		    .then(() => this.device.selectAlternateInterface(this.interfaceNumber, 0))
 		    .then(() => {
 
-		    	let baud = 921600;
+		    	let baud = this.portConfiguration.baudrate;
 
 /*		    	console.log("controlTransfer out now for " + this.interfaceNumber)
 		    	console.log("req: " + this.#FTDI_SIO_SET_BAUD_RATE)
@@ -866,7 +867,7 @@ class WebUSBSerialDevice {
 			if (!(device in this.devices))
 				this.devices.push(device);
 
-			return new WebUSBSerialPort(device);
+			return new WebUSBSerialPort(device, this.configuration);
 		} catch (e) {
 			throw new Error(e);
 		}


### PR DESCRIPTION
This PR updates the example to be up to date with the actual code.
The `baudrate` provided in config is now respected by the library.

Thank you very much for sharing this WebUSB code! Feel free to accept or reject this small contribution.